### PR TITLE
Inherit EventEmitter where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Other npm scripts in `package.json` are not supported at this time and may cause
 
 ### KQStream
 
-The `KQStream` class processes socket messages from a Killer Queen cabinet. You can set up a callback method for each type of supported event. These callback methods receive objects that contain event data in a deserialized format.
+The `KQStream` class is an [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) that processes socket messages from a Killer Queen cabinet. You can set up a callback method for each type of supported event. These callback methods receive objects that contain event data in a deserialized format.
 
 #### ```new KQStream(options?: KQStreamOptions)```
 

--- a/src/lib/GameStats.ts
+++ b/src/lib/GameStats.ts
@@ -1,3 +1,4 @@
+import { ProtectedEventEmitter } from '../lib/ts-eventemitter';
 import * as uuid from 'uuid/v4';
 import { KQStream, Character, PlayerKill } from './KQStream';
 
@@ -35,18 +36,15 @@ export interface KQStat {
     value: number;
 }
 
-export type GameStatsCallback<T> = (data: T) => any;
-
-interface GameStatsCallbackDictionary<T> {
-    [id: string]: GameStatsCallback<T>;
+interface Events {
+    'change': KQStat;
 }
 
-export class GameStats {
+export class GameStats extends ProtectedEventEmitter<Events> {
     private stream: KQStream;
     private hasGameStartBeenEncountered: boolean;
     private gameStats: GameStatsType;
     private gameState: GameStateType;
-    private onChange: GameStatsCallbackDictionary<KQStat>;
 
     /**
      * Complete list of valid statistic types.
@@ -142,54 +140,9 @@ export class GameStats {
     }
 
     constructor(stream: KQStream) {
+        super();
         this.stream = stream;
         this.hasGameStartBeenEncountered = false;
-        this.onChange = {};
-    }
-
-    on(eventType: 'change', callback: GameStatsCallback<KQStat>): string;
-    on(eventType: string, callback: GameStatsCallback<any>): string {
-        let id = uuid();
-        switch (eventType) {
-        case 'change':
-            while (this.onChange[id] !== undefined) {
-                id = uuid();
-            }
-            this.onChange[id] = callback;
-            break;
-        default:
-            throw new Error(`${eventType} is not a supported event type`);
-        }
-        return id;
-    }
-
-    off(eventType: 'change', id?: string): boolean;
-    off(eventType: string, id?: string): boolean {
-        let removed = false;
-        if (id !== undefined) {
-            switch (eventType) {
-            case 'change':
-                if (this.onChange[id] !== undefined) {
-                    delete this.onChange[id];
-                    removed = true;
-                }
-                break;
-            default:
-                throw new Error(`${eventType} is not a supported event type`);   
-            }
-        } else {
-            let keys: string[] = [];
-            switch (eventType) {
-            case 'change':
-                keys = Object.keys(this.onChange);
-                removed = keys.length > 0;
-                this.onChange = {};
-                break;
-            default:
-                throw new Error(`${eventType} is not a supported event type`);
-            }
-        }
-        return removed;
     }
 
     start() {
@@ -214,23 +167,18 @@ export class GameStats {
      * @param filter The statistics to filter
      */
     trigger(eventType: 'change', filter?: GameStatsFilter) {
-        const ids = Object.keys(this.onChange);
-        if (ids.length > 0) {
-            if (filter === undefined) {
-                filter = GameStats.defaultChangeFilter;
-            }
-            for (let character of Object.keys(filter)) {
-                const characterNumber = Number(character);
-                if (!isNaN(characterNumber)) {
-                    for (let statistic of filter[character]) {
-                        for (let id of ids) {
-                            this.onChange[id]({
-                                character: characterNumber,
-                                statistic: statistic,
-                                value: this.gameStats[characterNumber][statistic]
-                            });
-                        }
-                    }
+        if (filter === undefined) {
+            filter = GameStats.defaultChangeFilter;
+        }
+        for (let character of Object.keys(filter)) {
+            const characterNumber = Number(character);
+            if (!isNaN(characterNumber)) {
+                for (let statistic of filter[character]) {
+                    this.protectedEmit('change', {
+                        character: characterNumber,
+                        statistic: statistic,
+                        value: this.gameStats[characterNumber][statistic]
+                    });
                 }
             }
         }

--- a/src/lib/ts-eventemitter/index.ts
+++ b/src/lib/ts-eventemitter/index.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from 'events';
+
+/**
+ * An `EventEmitter` with strictly typed events.
+ * 
+ * `T` is an object whose keys are the event name and whose values
+ * are the argument type passed to the respective event type.
+ */
+export class TypedEventEmitter<T> extends EventEmitter {
+    addListener(event: keyof T, listener: (arg: T[typeof event]) => void): this {
+        return super.addListener(event, listener);
+    }
+    on(event: keyof T, listener: (arg: T[typeof event]) => void): this {
+        return super.on(event, listener);
+    }
+    once(event: keyof T, listener: (arg: T[typeof event]) => void): this {
+        return super.once(event, listener);
+    }
+    prependListener(event: keyof T, listener: (arg: T[typeof event]) => void): this {
+        return super.prependListener(event, listener);
+    }
+    prependOnceListener(event: keyof T, listener: (arg: T[typeof event]) => void): this {
+        return super.prependOnceListener(event, listener);
+    }
+    removeListener(event: keyof T, listener: (arg: T[typeof event]) => void): this {
+        return super.removeListener(event, listener);
+    }
+    removeAllListeners(event?: keyof T): this {
+        return super.removeAllListeners(event);
+    }
+    listeners(event: keyof T): Function[] {
+        return super.listeners(event);
+    }
+    rawListeners(event: keyof T): Function[] {
+        return super.rawListeners(event);
+    }
+    eventNames(): Array<keyof T> {
+        return super.eventNames() as any;
+    }
+    listenerCount(type: keyof T): number {
+        return super.listenerCount(type);
+    }
+    emit(event: keyof T, arg: T[typeof event]): boolean {
+        return super.emit(event, arg);
+    }
+}
+
+/**
+ * A `TypedEventEmitter` class that can only emit events from within the class.
+ * 
+ * `EventEmitter#emit` does nothing and always returns false. Use `ProtectedEventEmitter#protectedEmit`
+ * to emit events from within the class
+ */
+export class ProtectedEventEmitter<T> extends TypedEventEmitter<T> {
+    /**
+     * @deprecated _NOP_, use `PrivateEventEmitter#privateEmit` to emit events from 
+     */
+    emit(event: keyof T, arg: T[typeof event]): boolean {
+        return false;
+    }
+    protected protectedEmit(event: keyof T, arg: T[typeof event]): boolean {
+        return super.emit(event, arg);
+    }
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as socket_io from 'socket.io';
 import { KQStream, KQStreamOptions } from '../lib/KQStream';
-import { GameStats } from '../lib/GameStats';
+import { GameStats, KQStat } from '../lib/GameStats';
 
 if (process.argv.length !== 4) {
     throw new Error('Incorrect usage!');
@@ -35,11 +35,12 @@ if (process.argv[2] === '-r') {
 
 const io = socket_io(8000);
 io.on('connection', (socket) => {
-    const id = gameStats.on('change', (data) => {
+    const changeListener = (data: KQStat) => {
         socket.emit('stat', data);
-    });
+    };
+    const id = gameStats.on('change', changeListener);
     socket.on('disconnect', () => {
-        gameStats.off('change', id);
+        gameStats.removeListener('change', changeListener);
     });
     gameStats.trigger('change');
 });


### PR DESCRIPTION
Typed [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) classes were implemented:

- `TypedEventEmitter`: an `EventEmitter` with strictly typed events
- `ProtectedEventEmitter`: a `TypedEventEmitter` that can only emit events from within the class

The following classes inherit `ProtectedEventEmitter`, eliminating their boilerplate event handling code:

- `KQStream`
- `GameStats`

**Breaking changes** in `KQStream` and `GameStats`:

- `#off` method has been replaced with `EventEmitter#removeListener`
- `#on` no longer returns a string, instead adhering to `EventEmitter#on`

The README has been updated to reflect these changes.

Fixes #7 