### PR TITLE
Reconnect on connection error

### DIFF
--- a/example/kqcab.ts
+++ b/example/kqcab.ts
@@ -6,3 +6,15 @@ const cab = new KQCab();
 const filepath = path.join(__dirname, 'socket_messages', 'non_tournament_mode_games.txt');
 const data = fs.readFileSync(filepath, 'utf8');
 cab.read(data);
+
+// Send playernames on keypress
+const stdin = process.stdin;
+stdin.setRawMode!(true);
+stdin.resume();
+stdin.setEncoding('utf8');
+stdin.on('data', (char) => {
+  if (char === '\u0003') {
+    process.exit();
+  }
+  cab.send('![k[playernames],v[,,,,,,,,,]]!');
+});

--- a/src/lib/GameStats.ts
+++ b/src/lib/GameStats.ts
@@ -142,11 +142,13 @@ export class GameStats extends ProtectedEventEmitter<Events> {
     constructor(stream: KQStream) {
         super();
         this.stream = stream;
-        this.hasGameStartBeenEncountered = false;
     }
 
     start() {
         this.resetStats();
+        this.hasGameStartBeenEncountered = false;
+        this.stream.removeAllListeners('playernames');
+        this.stream.removeAllListeners('playerKill');
         this.stream.on('playernames', () => {
             this.resetStats();
             if (!this.hasGameStartBeenEncountered) {

--- a/test/KQStream.ts
+++ b/test/KQStream.ts
@@ -1,15 +1,15 @@
 import { expect } from 'chai';
 import { KQCab } from '../src/lib/KQCab';
-import { Character, Events, KQStream } from '../src/lib/KQStream';
+import { Character, GameEvents, KQStream } from '../src/lib/KQStream';
 
 type TestEvent = {
     timestamp: string;
-    type: keyof Events;
+    type: keyof GameEvents;
     data: string;
 };
 
 type CabEvents = {
-    [K in keyof Events]: Events[K][];
+    [K in keyof GameEvents]: GameEvents[K][];
 };
 
 describe('KQStream', () => {


### PR DESCRIPTION
Behavior for different commands:

- `npm run start`
  - Scan for IP addresses on local network with port 12749 open every 10 seconds until at least one is found
  - Connect to first IP address found
  - If connection fails or errors, go to beginning...
- `npm run start -- -c [address]`
  - Try connecting to address every 10 seconds until connection succeeds
  - If connection errors, go to beginning...

To support this feature, new events have been added to `KQStream`:

- `connectionClose`: fired when connection is closed, either by the client or server
- `connectionError`: fired when a connection error occurs (e.g. connection lost)
  - For listener `(arg) => void`, use `arg.connected` to see if the client is still connected

These new events are `StreamEvents`, while messages from the cab are `GameEvents`. Together they constitute all the events you can use with `KQStream`.

Also fixed `GameStats#start` behavior to allow for multiple calls to the method:

- Sets `this.hasGameStartBeenEncountered = false`, instead of in the constructor
- Removes all `GameEvents` listeners from the `KQStream` it uses, allowing these listeners to be readded