### PR TITLE
Add "stroke" outline css to killboard

### DIFF
--- a/src/client/killboard/Killboard.css
+++ b/src/client/killboard/Killboard.css
@@ -71,6 +71,11 @@ th:not(:nth-child(1)), td:not(:nth-child(1)) {
   font-size: 60pt;
   text-align: center;
   line-height: normal;
+  text-shadow:
+    -2px -2px 0 #000,
+     2px -2px 0 #000,
+    -2px  2px 0 #000,
+     2px  2px 0 #000;
 }
 
 .killboard.horizontal div.crowns {


### PR DESCRIPTION
Simple little feature that adds an outline to the text of the killboard.  This (hopefully) increases readability of the kill counts, especially on Queen:

Before
![image](https://user-images.githubusercontent.com/112752/43692829-9d19e56a-98f8-11e8-9bb9-89546dcc6714.png)

After
![image](https://user-images.githubusercontent.com/112752/43692812-867dbea8-98f8-11e8-92bf-87578279dc41.png)


I'm not set on this being the exact implementation used -- this just works in OBS.  The width of 2px was chosen arbitrarily and should be replaced with anything deemed nicer.
